### PR TITLE
Fix Crocodile spidev_probe warning and disable micfil

### DIFF
--- a/arch/arm64/boot/dts/freescale/crocodile.dts
+++ b/arch/arm64/boot/dts/freescale/crocodile.dts
@@ -328,7 +328,7 @@
 	pinctrl-0 = <&pinctrl_ecspi2>;
 	status = "okay";
 	spidev@0x00 {
-	compatible = "spidev";
+	compatible = "lgs-crocodile,spi";
 	spi-max-frequency = <10000000>;
 	reg = <0>;
 	};

--- a/arch/arm64/boot/dts/freescale/crocodile.dts
+++ b/arch/arm64/boot/dts/freescale/crocodile.dts
@@ -314,7 +314,7 @@
 	assigned-clocks = <&clk IMX8MM_CLK_PDM>;
 	assigned-clock-parents = <&clk IMX8MM_AUDIO_PLL1_OUT>;
 	assigned-clock-rates = <196608000>;
-	status = "okay";
+	status = "disabled";
 };
 
 &snvs_pwrkey {

--- a/drivers/spi/spidev.c
+++ b/drivers/spi/spidev.c
@@ -678,6 +678,7 @@ static const struct of_device_id spidev_dt_ids[] = {
 	{ .compatible = "lwn,bk4" },
 	{ .compatible = "dh,dhcom-board" },
 	{ .compatible = "menlo,m53cpld" },
+	{ .compatible = "lgs-crocodile,spi" },
 	{},
 };
 MODULE_DEVICE_TABLE(of, spidev_dt_ids);


### PR DESCRIPTION
arm64: dts: crocodile: Change ecspi2 compatible to "lgs-crocodile,spi"
spi: spidev: Add compatible for lgs-crocodile spi.
arm64: dts: crocodile: Disable the node micfil to release GPIO

Signed-off-by: LI Qingwu <Qing-wu.Li@leica-geosystems.com.cn>