### PR TITLE
MLK-24708 spi: imx: handle EPROBE_DEFER when get cs-gpios number

### DIFF
--- a/drivers/spi/spi-imx.c
+++ b/drivers/spi/spi-imx.c
@@ -1775,8 +1775,13 @@ static int spi_imx_probe(struct platform_device *pdev)
 	/* Request GPIO CS lines, if any */
 	if (!spi_imx->slave_mode && master->cs_gpios) {
 		for (i = 0; i < master->num_chipselect; i++) {
-			if (!gpio_is_valid(master->cs_gpios[i]))
+			if (!gpio_is_valid(master->cs_gpios[i])) {
+				if (master->cs_gpios[i] == -EPROBE_DEFER) {
+					ret = -EPROBE_DEFER;
+					goto out_spi_bitbang;
+				}
 				continue;
+			}
 
 			ret = devm_gpio_request(&pdev->dev,
 						master->cs_gpios[i],


### PR DESCRIPTION
If SPI is probed before the GPIO driver, it may miss the cs-gpio
configuration in dtb.
Add defer probe handler to wait GPIO driver probe.

Reviewed-by: Fugang Duan <fugang.duan@nxp.com>
Signed-off-by: Clark Wang <xiaoning.wang@nxp.com>
(cherry picked from commit c2b2a4d1006b48ab311d2f948e83490d8ea453f5)
Signed-off-by: LI Qingwu <Qing-wu.Li@leica-geosystems.com.cn>


pick from "https://github.com/varigit/linux-imx/blob/imx_5.4.70_2.3.0_var01/drivers/spi/spi-imx.c"