### PR TITLE
[leica/5.4-2.1.x-imx/dragonstaff]: Add DTB support for P1

### DIFF
--- a/arch/arm64/boot/dts/freescale/ap20-pt1.dts
+++ b/arch/arm64/boot/dts/freescale/ap20-pt1.dts
@@ -28,6 +28,24 @@
 				MX8MM_IOMUXC_I2C3_SDA_GPIO5_IO19		0x16
 			>;
 		};
+
+		/*
+		 * Route only ECSPI1_SCLK and ECSPI1_MOSI pins to UART due to
+		 * interchanged RTS/CTS lines
+		 */
+		pinctrl_uart3: uart3grp {
+			fsl,pins = <
+				MX8MM_IOMUXC_ECSPI1_SCLK_UART3_DCE_RX		0x140
+				MX8MM_IOMUXC_ECSPI1_MOSI_UART3_DCE_TX		0x140
+			>;
+		};
+
+		/* Route ECSPI1_SS0 pin to GPIO due to interchanged RTS/CTS lines */
+		pinctrl_uart3fix: uart3fixgrp {
+			fsl,pins = <
+				MX8MM_IOMUXC_ECSPI1_SS0_GPIO5_IO9		0x16
+			>;
+		};
 	};
 };
 
@@ -40,6 +58,18 @@
 };
 
 &gpio5 {
+	/*
+	 * As BLE_CPU_UART3_RTS and BLE_CPU_UART3_CTS lines are interchanged
+	 * BLE_CPU_UART3_CTS respectively GPIO5_IO09 needs to be hogged low in
+	 * order to signal that i.MX ready to receive data.
+	 */
+	ble_cpu_uart3_cts {
+		gpio-hog;
+		gpios = <9 GPIO_ACTIVE_HIGH>;
+		output-low;
+		line-name = "BLE_CPU_UART3_CTS";
+	};
+
 	/*
 	 * As I2C3 lines are interchanged, no communication with USB2514B is
 	 * possible. CPU_USBH_I2C_SDA (instead of CPU_USBH_I2C_SCL) is
@@ -57,4 +87,9 @@
 		output-low;
 		line-name = "CPU_USBH_I2C_SCL";
 	};
+};
+
+&uart3 {
+	/* delete "uart-has-rtscts" property due to interchanged RTS/CTS lines */
+	/delete-property/ uart-has-rtscts;
 };

--- a/arch/arm64/boot/dts/freescale/ap20-pt1.dts
+++ b/arch/arm64/boot/dts/freescale/ap20-pt1.dts
@@ -20,10 +20,41 @@
 	model = "AP20 PT1";
 };
 
+&iomuxc {
+	imx8mm-var-dart {
+		/* Route I2C3_SDA pin to GPIO due to interchanged I2C lines */
+		pinctrl_i2c3: i2c3grp {
+			fsl,pins = <
+				MX8MM_IOMUXC_I2C3_SDA_GPIO5_IO19		0x16
+			>;
+		};
+	};
+};
+
 &fec1 {
 	/*
 	 * disable reset gpio since PHY is not detected anymore after a reset.
 	 */
 	/delete-property/ phy-reset-gpios;
 	/delete-property/ phy-reset-duration;
+};
+
+&gpio5 {
+	/*
+	 * As I2C3 lines are interchanged, no communication with USB2514B is
+	 * possible. CPU_USBH_I2C_SDA (instead of CPU_USBH_I2C_SCL) is
+	 * connected to pin "SCL/CFG_SEL0" of USB2514B and set to HIGH by a
+	 * pullup resistor on SOM. Therefore the initial interface
+	 * configuration of USB2514B is set to SMBus and a configuration over
+	 * I2C3 is expected.
+	 * In order to load the default configuration of USB2514B the
+	 * CFG_SEL[0] needs to be set to 0 i.e. hog GPIO5_IO19 to low before
+	 * releasing reset.
+	 */
+	cpu_usbh_i2c_scl {
+		gpio-hog;
+		gpios = <19 GPIO_ACTIVE_HIGH>;
+		output-low;
+		line-name = "CPU_USBH_I2C_SCL";
+	};
 };

--- a/arch/arm64/boot/dts/freescale/ap20-pt1.dts
+++ b/arch/arm64/boot/dts/freescale/ap20-pt1.dts
@@ -19,3 +19,11 @@
 / {
 	model = "AP20 PT1";
 };
+
+&fec1 {
+	/*
+	 * disable reset gpio since PHY is not detected anymore after a reset.
+	 */
+	/delete-property/ phy-reset-gpios;
+	/delete-property/ phy-reset-duration;
+};

--- a/arch/arm64/boot/dts/freescale/ap20-pt1.dts
+++ b/arch/arm64/boot/dts/freescale/ap20-pt1.dts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2021 Leica Geosystems AG
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/dts-v1/;
+
+#include "ap20.dtsi"
+
+/ {
+	model = "AP20 PT1";
+};

--- a/arch/arm64/boot/dts/freescale/ap20.dtsi
+++ b/arch/arm64/boot/dts/freescale/ap20.dtsi
@@ -99,6 +99,15 @@
 			>;
 		};
 
+		pinctrl_uart3: uart3grp {
+			fsl,pins = <
+				MX8MM_IOMUXC_ECSPI1_SCLK_UART3_DCE_RX		0x140
+				MX8MM_IOMUXC_ECSPI1_MOSI_UART3_DCE_TX		0x140
+				MX8MM_IOMUXC_ECSPI1_SS0_UART3_DCE_RTS_B		0x140
+				MX8MM_IOMUXC_ECSPI1_MISO_UART3_DCE_CTS_B    	0x140
+			>;
+		};
+
 		pinctrl_usdhc3: usdhc3grp {
 			fsl,pins = <
 				MX8MM_IOMUXC_NAND_WE_B_USDHC3_CLK		0x190
@@ -368,6 +377,14 @@
 &uart2 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_uart2>;
+	status = "okay";
+};
+
+/* BLE Module */
+&uart3 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart3>;
+	uart-has-rtscts;
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/freescale/ap20.dtsi
+++ b/arch/arm64/boot/dts/freescale/ap20.dtsi
@@ -152,6 +152,47 @@
 				MX8MM_IOMUXC_GPIO1_IO02_WDOG1_WDOG_B		0xc6
 			>;
 		};
+
+		pinctrl_usbhub: usbhubgrp {
+			fsl,pins = <
+				MX8MM_IOMUXC_GPIO1_IO01_GPIO1_IO1		0x16
+			>;
+		};
+
+		pinctrl_imu: imugrp {
+			fsl,pins = <
+				MX8MM_IOMUXC_GPIO1_IO05_GPIO1_IO5		0x16
+				MX8MM_IOMUXC_GPIO1_IO06_GPIO1_IO6		0x16
+				MX8MM_IOMUXC_GPIO1_IO08_GPIO1_IO8		0x16
+			>;
+		};
+
+		pinctrl_blemod: blemodgrp {
+			fsl,pins = <
+				MX8MM_IOMUXC_GPIO1_IO03_GPIO1_IO3		0x16
+			>;
+		};
+
+		pinctrl_gnss: gnssgrp {
+			fsl,pins = <
+				MX8MM_IOMUXC_GPIO1_IO15_GPIO1_IO15		0x16
+			>;
+		};
+
+		pinctl_enet: enetgrp {
+			fsl,pins = <
+				MX8MM_IOMUXC_GPIO1_IO10_GPIO1_IO10		0x1C6
+				MX8MM_IOMUXC_GPIO1_IO11_GPIO1_IO11		0x1C6
+			>;
+		};
+
+		pinctl_debug: debuggrp {
+			fsl,pins = <
+				MX8MM_IOMUXC_SPDIF_TX_GPIO5_IO3			0x16
+				MX8MM_IOMUXC_SPDIF_RX_GPIO5_IO4			0x16
+				MX8MM_IOMUXC_SPDIF_EXT_CLK_GPIO5_IO5		0x16
+			>;
+		};
 	};
 };
 
@@ -374,4 +415,32 @@
 
 &snvs_rtc {
 	status = "disabled";
+};
+
+&gpio1 {
+	gpio-line-names =
+		"",
+		"CPU_USBH_RESET_N",
+		"",
+		"CPU_BLE_RST_N",
+		"",
+		"CPU_IMU_DATA_EN",
+		"CPU_IMU_ONOFF_N",
+		"",
+		"CPU_IMU_DET",
+		"",
+		"CPU_ENET_INT",
+		"CPU_ENET_WOL",
+		"CPU_GNSS_EXT_INT",
+		"",
+		"MCU_CPU_RDY",
+		"CPU_GNSS_RST_N";
+};
+
+&gpio5 {
+	gpio-line-names =
+		"", "", "",
+		"CPU_GPIO5_IO03",
+		"CPU_GPIO5_IO04",
+		"CPU_GPIO5_IO05";
 };

--- a/arch/arm64/boot/dts/freescale/ap20.dtsi
+++ b/arch/arm64/boot/dts/freescale/ap20.dtsi
@@ -41,6 +41,26 @@
 	pinctrl-names = "default";
 
 	imx8mm-var-dart {
+		pinctrl_fec1: fec1grp {
+			fsl,pins = <
+				MX8MM_IOMUXC_ENET_MDC_ENET1_MDC			0x3
+				MX8MM_IOMUXC_ENET_MDIO_ENET1_MDIO		0x3
+				MX8MM_IOMUXC_ENET_TD3_ENET1_RGMII_TD3		0x1f
+				MX8MM_IOMUXC_ENET_TD2_ENET1_RGMII_TD2		0x1f
+				MX8MM_IOMUXC_ENET_TD1_ENET1_RGMII_TD1		0x1f
+				MX8MM_IOMUXC_ENET_TD0_ENET1_RGMII_TD0		0x1f
+				MX8MM_IOMUXC_ENET_RD3_ENET1_RGMII_RD3		0x91
+				MX8MM_IOMUXC_ENET_RD2_ENET1_RGMII_RD2		0x91
+				MX8MM_IOMUXC_ENET_RD1_ENET1_RGMII_RD1		0x91
+				MX8MM_IOMUXC_ENET_RD0_ENET1_RGMII_RD0		0x91
+				MX8MM_IOMUXC_ENET_TXC_ENET1_RGMII_TXC		0x1f
+				MX8MM_IOMUXC_ENET_RXC_ENET1_RGMII_RXC		0x91
+				MX8MM_IOMUXC_ENET_RX_CTL_ENET1_RGMII_RX_CTL	0x91
+				MX8MM_IOMUXC_ENET_TX_CTL_ENET1_RGMII_TX_CTL	0x1f
+				MX8MM_IOMUXC_GPIO1_IO13_GPIO1_IO13		0x19
+			>;
+		};
+
 		pinctrl_flexspi0: flexspi0grp {
 			fsl,pins = <
 				MX8MM_IOMUXC_NAND_ALE_QSPI_A_SCLK		0x1c2
@@ -273,6 +293,27 @@
 
 &mu {
 	status = "okay";
+};
+
+&fec1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_fec1>;
+	phy-mode = "rgmii";
+	phy-handle = <&ethphy0>;
+	phy-reset-gpios = <&gpio1 13 GPIO_ACTIVE_LOW>;
+	phy-reset-duration = <10>;
+	fsl,magic-packet;
+	status = "okay";
+
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		ethphy0: ethernet-phy@0 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <0>;
+		};
+	};
 };
 
 /* Console */

--- a/arch/arm64/boot/dts/freescale/ap20.dtsi
+++ b/arch/arm64/boot/dts/freescale/ap20.dtsi
@@ -108,6 +108,13 @@
 			>;
 		};
 
+		pinctrl_uart4: uart4grp {
+			fsl,pins = <
+				MX8MM_IOMUXC_UART4_RXD_UART4_DCE_RX		0x140
+				MX8MM_IOMUXC_UART4_TXD_UART4_DCE_TX		0x140
+			>;
+		};
+
 		pinctrl_usdhc3: usdhc3grp {
 			fsl,pins = <
 				MX8MM_IOMUXC_NAND_WE_B_USDHC3_CLK		0x190
@@ -385,6 +392,13 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_uart3>;
 	uart-has-rtscts;
+	status = "okay";
+};
+
+/* GNSS */
+&uart4 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart4>;
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/freescale/ap20.dtsi
+++ b/arch/arm64/boot/dts/freescale/ap20.dtsi
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2018 NXP
+ * Copyright 2019 Variscite Ltd.
+ * Copyright (C) 2021 Leica Geosystems AG
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <dt-bindings/usb/pd.h>
+#include "imx8mm.dtsi"
+
+/ {
+	compatible = "variscite,dart-mx8mm", "fsl,imx8mm";
+
+	chosen {
+		bootargs = "console=ttymxc0,115200 earlycon=ec_imx6q,0x30860000,115200";
+		stdout-path = &uart1;
+	};
+
+	reserved-memory {
+		/* cma region is provided by kernel command line as cma=<size>M */
+		/delete-node/ linux,cma;
+
+		/delete-node/ rpmsg@b8000000;
+		rpmsg_reserved: rpmsg@40000000 {
+			no-map;
+			reg = <0 0x40000000 0 0x400000>;
+		};
+	};
+};
+
+&iomuxc {
+	pinctrl-names = "default";
+
+	imx8mm-var-dart {
+		pinctrl_flexspi0: flexspi0grp {
+			fsl,pins = <
+				MX8MM_IOMUXC_NAND_ALE_QSPI_A_SCLK		0x1c2
+				MX8MM_IOMUXC_NAND_CE0_B_QSPI_A_SS0_B		0x82
+				MX8MM_IOMUXC_NAND_DATA00_QSPI_A_DATA0		0x82
+				MX8MM_IOMUXC_NAND_DATA01_QSPI_A_DATA1		0x82
+				MX8MM_IOMUXC_NAND_DATA02_QSPI_A_DATA2		0x82
+				MX8MM_IOMUXC_NAND_DATA03_QSPI_A_DATA3		0x82
+			>;
+		};
+
+		pinctrl_i2c1: i2c1grp {
+			fsl,pins = <
+				MX8MM_IOMUXC_I2C1_SCL_I2C1_SCL			0x400001c3
+				MX8MM_IOMUXC_I2C1_SDA_I2C1_SDA			0x400001c3
+			>;
+		};
+
+		pinctrl_pmic: pmicirq {
+			fsl,pins = <
+				MX8MM_IOMUXC_SD1_DATA6_GPIO2_IO8		0x41
+			>;
+		};
+
+		pinctrl_uart1: uart1grp {
+			fsl,pins = <
+				MX8MM_IOMUXC_UART1_RXD_UART1_DCE_RX		0x140
+				MX8MM_IOMUXC_UART1_TXD_UART1_DCE_TX		0x140
+			>;
+		};
+
+		pinctrl_uart2: uart2grp {
+			fsl,pins = <
+				MX8MM_IOMUXC_UART2_RXD_UART2_DCE_RX		0x140
+				MX8MM_IOMUXC_UART2_TXD_UART2_DCE_TX		0x140
+			>;
+		};
+
+		pinctrl_usdhc3: usdhc3grp {
+			fsl,pins = <
+				MX8MM_IOMUXC_NAND_WE_B_USDHC3_CLK		0x190
+				MX8MM_IOMUXC_NAND_WP_B_USDHC3_CMD		0x1d0
+				MX8MM_IOMUXC_NAND_DATA04_USDHC3_DATA0		0x1d0
+				MX8MM_IOMUXC_NAND_DATA05_USDHC3_DATA1		0x1d0
+				MX8MM_IOMUXC_NAND_DATA06_USDHC3_DATA2		0x1d0
+				MX8MM_IOMUXC_NAND_DATA07_USDHC3_DATA3		0x1d0
+				MX8MM_IOMUXC_NAND_RE_B_USDHC3_DATA4		0x1d0
+				MX8MM_IOMUXC_NAND_CE2_B_USDHC3_DATA5		0x1d0
+				MX8MM_IOMUXC_NAND_CE3_B_USDHC3_DATA6		0x1d0
+				MX8MM_IOMUXC_NAND_CLE_USDHC3_DATA7		0x1d0
+				MX8MM_IOMUXC_NAND_CE1_B_USDHC3_STROBE 		0x190
+			>;
+		};
+
+		pinctrl_usdhc3_100mhz: usdhc3grp100mhz {
+			fsl,pins = <
+				MX8MM_IOMUXC_NAND_WE_B_USDHC3_CLK		0x194
+				MX8MM_IOMUXC_NAND_WP_B_USDHC3_CMD		0x1d4
+				MX8MM_IOMUXC_NAND_DATA04_USDHC3_DATA0		0x1d4
+				MX8MM_IOMUXC_NAND_DATA05_USDHC3_DATA1		0x1d4
+				MX8MM_IOMUXC_NAND_DATA06_USDHC3_DATA2		0x1d4
+				MX8MM_IOMUXC_NAND_DATA07_USDHC3_DATA3		0x1d4
+				MX8MM_IOMUXC_NAND_RE_B_USDHC3_DATA4		0x1d4
+				MX8MM_IOMUXC_NAND_CE2_B_USDHC3_DATA5		0x1d4
+				MX8MM_IOMUXC_NAND_CE3_B_USDHC3_DATA6		0x1d4
+				MX8MM_IOMUXC_NAND_CLE_USDHC3_DATA7		0x1d4
+				MX8MM_IOMUXC_NAND_CE1_B_USDHC3_STROBE 		0x194
+			>;
+		};
+
+		pinctrl_usdhc3_200mhz: usdhc3grp200mhz {
+			fsl,pins = <
+				MX8MM_IOMUXC_NAND_WE_B_USDHC3_CLK		0x196
+				MX8MM_IOMUXC_NAND_WP_B_USDHC3_CMD		0x1d6
+				MX8MM_IOMUXC_NAND_DATA04_USDHC3_DATA0		0x1d6
+				MX8MM_IOMUXC_NAND_DATA05_USDHC3_DATA1		0x1d6
+				MX8MM_IOMUXC_NAND_DATA06_USDHC3_DATA2		0x1d6
+				MX8MM_IOMUXC_NAND_DATA07_USDHC3_DATA3		0x1d6
+				MX8MM_IOMUXC_NAND_RE_B_USDHC3_DATA4		0x1d6
+				MX8MM_IOMUXC_NAND_CE2_B_USDHC3_DATA5		0x1d6
+				MX8MM_IOMUXC_NAND_CE3_B_USDHC3_DATA6		0x1d6
+				MX8MM_IOMUXC_NAND_CLE_USDHC3_DATA7		0x1d6
+				MX8MM_IOMUXC_NAND_CE1_B_USDHC3_STROBE 		0x196
+			>;
+		};
+
+		pinctrl_wdog: wdoggrp {
+			fsl,pins = <
+				MX8MM_IOMUXC_GPIO1_IO02_WDOG1_WDOG_B		0xc6
+			>;
+		};
+	};
+};
+
+&i2c1 {
+	clock-frequency = <100000>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c1>;
+	status = "okay";
+
+	pmic@4b {
+		reg = <0x4b>;
+		compatible = "rohm,bd71847";
+		pinctrl-0 = <&pinctrl_pmic>;
+		interrupt-parent = <&gpio2>;
+		interrupts = <8 GPIO_ACTIVE_LOW>;
+		rohm,reset-snvs-powered;
+
+		regulators {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			buck1_reg: regulator@0 {
+				reg = <0>;
+				regulator-compatible = "BUCK1";
+				regulator-min-microvolt = <700000>;
+				regulator-max-microvolt = <1300000>;
+				regulator-boot-on;
+				regulator-always-on;
+				regulator-ramp-delay = <1250>;
+			};
+
+			buck2_reg: regulator@1 {
+				reg = <1>;
+				regulator-compatible = "BUCK2";
+				regulator-min-microvolt = <700000>;
+				regulator-max-microvolt = <1300000>;
+				regulator-boot-on;
+				regulator-always-on;
+				regulator-ramp-delay = <1250>;
+				rohm,dvs-run-voltage = <1000000>;
+				rohm,dvs-idle-voltage = <900000>;
+			};
+
+			buck3_reg: regulator@2 {
+				// BUCK5 in datasheet
+				reg = <2>;
+				regulator-compatible = "BUCK3";
+				regulator-min-microvolt = <700000>;
+				regulator-max-microvolt = <1350000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+
+			buck4_reg: regulator@3 {
+				// BUCK6 in datasheet
+				reg = <3>;
+				regulator-compatible = "BUCK4";
+				regulator-min-microvolt = <3000000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+
+			buck5_reg: regulator@4 {
+				// BUCK7 in datasheet
+				reg = <4>;
+				regulator-compatible = "BUCK5";
+				regulator-min-microvolt = <1605000>;
+				regulator-max-microvolt = <1995000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+
+			buck6_reg: regulator@5 {
+				// BUCK8 in datasheet
+				reg = <5>;
+				regulator-compatible = "BUCK6";
+				regulator-min-microvolt = <800000>;
+				regulator-max-microvolt = <1400000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+
+			ldo1_reg: regulator@6 {
+				reg = <6>;
+				regulator-compatible = "LDO1";
+				regulator-min-microvolt = <3000000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+
+			ldo2_reg: regulator@7 {
+				reg = <7>;
+				regulator-compatible = "LDO2";
+				regulator-min-microvolt = <900000>;
+				regulator-max-microvolt = <900000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+
+			ldo3_reg: regulator@8 {
+				reg = <8>;
+				regulator-compatible = "LDO3";
+				regulator-min-microvolt = <1800000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+
+			ldo4_reg: regulator@9 {
+				reg = <9>;
+				regulator-compatible = "LDO4";
+				regulator-min-microvolt = <900000>;
+				regulator-max-microvolt = <1800000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+
+			ldo5_reg: regulator@12 {
+				reg = <12>;
+				regulator-compatible = "LDO5";
+				regulator-min-microvolt = <1800000>;
+				regulator-max-microvolt = <1800000>;
+				regulator-always-on;
+			};
+
+			ldo6_reg: regulator@11 {
+				reg = <11>;
+				regulator-compatible = "LDO6";
+				regulator-min-microvolt = <900000>;
+				regulator-max-microvolt = <1800000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+		};
+	};
+};
+
+&mu {
+	status = "okay";
+};
+
+/* Console */
+&uart1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart1>;
+	status = "okay";
+};
+
+/* MCU */
+&uart2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart2>;
+	status = "okay";
+};
+
+&usbotg1 {
+	dr_mode = "otg";
+	picophy,pre-emp-curr-control = <3>;
+	picophy,dc-vol-level-adjust = <7>;
+	status = "okay";
+};
+
+&usbotg2 {
+	dr_mode = "host";
+	picophy,pre-emp-curr-control = <3>;
+	picophy,dc-vol-level-adjust = <7>;
+	status = "okay";
+};
+
+/* EMMC */
+&usdhc3 {
+	pinctrl-names = "default", "state_100mhz", "state_200mhz";
+	pinctrl-0 = <&pinctrl_usdhc3>;
+	pinctrl-1 = <&pinctrl_usdhc3_100mhz>;
+	pinctrl-2 = <&pinctrl_usdhc3_200mhz>;
+	bus-width = <8>;
+	non-removable;
+	status = "okay";
+};
+
+&wdog1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_wdog>;
+	fsl,ext-reset-output;
+	status = "okay";
+};
+
+&A53_0 {
+	arm-supply = <&buck2_reg>;
+};
+
+&flexspi {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_flexspi0>;
+	status = "disabled";
+};
+
+&snvs_rtc {
+	status = "disabled";
+};

--- a/arch/arm64/boot/dts/freescale/ap20.dtsi
+++ b/arch/arm64/boot/dts/freescale/ap20.dtsi
@@ -331,7 +331,7 @@
 };
 
 &usbotg1 {
-	dr_mode = "otg";
+	dr_mode = "peripheral";
 	picophy,pre-emp-curr-control = <3>;
 	picophy,dc-vol-level-adjust = <7>;
 	status = "okay";


### PR DESCRIPTION
Add initial support for AP20 PT1:
- Port and adapt common nodes from `dragonstaff.dts` to `ap20.dtsi`
- Introduce new `ap20-pt1.dts` based on `ap20.dtsi` containing fixes for PT1 