### PR TITLE
[leica/5.4-2.1.x-imx/dragonstaff]: ap20-pt1: change model name

### DIFF
--- a/arch/arm64/boot/dts/freescale/ap20-pt1.dts
+++ b/arch/arm64/boot/dts/freescale/ap20-pt1.dts
@@ -17,7 +17,7 @@
 #include "ap20.dtsi"
 
 / {
-	model = "AP20 PT1";
+	model = "AP20-PT1";
 };
 
 &iomuxc {


### PR DESCRIPTION
We are going to use model name in test scripts. It was agreed to use common pattern `<name>[-variant]` accross all products for the model name to be easily identified, e.g.: `AP20-PT1`, `AP20-PT2`, `AP20`.