### PR TITLE
[leica/5.4-2.1.x-imx/dragonstaff]: arm64: dts: ap20: align PMIC configuration with imx8mm-var-dart.dts

### DIFF
--- a/arch/arm64/boot/dts/freescale/ap20.dtsi
+++ b/arch/arm64/boot/dts/freescale/ap20.dtsi
@@ -212,20 +212,18 @@
 	status = "okay";
 
 	pmic@4b {
-		reg = <0x4b>;
+		status = "okay";
 		compatible = "rohm,bd71847";
+		reg = <0x4b>;
+		pinctrl-names = "default";
 		pinctrl-0 = <&pinctrl_pmic>;
 		interrupt-parent = <&gpio2>;
-		interrupts = <8 GPIO_ACTIVE_LOW>;
+		interrupts = <8 IRQ_TYPE_LEVEL_LOW>;
 		rohm,reset-snvs-powered;
 
 		regulators {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			buck1_reg: regulator@0 {
-				reg = <0>;
-				regulator-compatible = "BUCK1";
+			buck1_reg: BUCK1 {
+				regulator-name = "BUCK1";
 				regulator-min-microvolt = <700000>;
 				regulator-max-microvolt = <1300000>;
 				regulator-boot-on;
@@ -233,9 +231,8 @@
 				regulator-ramp-delay = <1250>;
 			};
 
-			buck2_reg: regulator@1 {
-				reg = <1>;
-				regulator-compatible = "BUCK2";
+			buck2_reg: BUCK2 {
+				regulator-name = "BUCK2";
 				regulator-min-microvolt = <700000>;
 				regulator-max-microvolt = <1300000>;
 				regulator-boot-on;
@@ -245,93 +242,82 @@
 				rohm,dvs-idle-voltage = <900000>;
 			};
 
-			buck3_reg: regulator@2 {
+			buck3_reg: BUCK3 {
 				// BUCK5 in datasheet
-				reg = <2>;
-				regulator-compatible = "BUCK3";
+				regulator-name = "BUCK3";
 				regulator-min-microvolt = <700000>;
 				regulator-max-microvolt = <1350000>;
 				regulator-boot-on;
 				regulator-always-on;
 			};
 
-			buck4_reg: regulator@3 {
+			buck4_reg: BUCK4 {
 				// BUCK6 in datasheet
-				reg = <3>;
-				regulator-compatible = "BUCK4";
-				regulator-min-microvolt = <3000000>;
+				regulator-name = "BUCK4";
+				regulator-min-microvolt = <2600000>;
 				regulator-max-microvolt = <3300000>;
 				regulator-boot-on;
 				regulator-always-on;
 			};
 
-			buck5_reg: regulator@4 {
+			buck5_reg: BUCK5 {
 				// BUCK7 in datasheet
-				reg = <4>;
-				regulator-compatible = "BUCK5";
+				regulator-name = "BUCK5";
 				regulator-min-microvolt = <1605000>;
 				regulator-max-microvolt = <1995000>;
 				regulator-boot-on;
 				regulator-always-on;
 			};
 
-			buck6_reg: regulator@5 {
+			buck6_reg: BUCK6 {
 				// BUCK8 in datasheet
-				reg = <5>;
-				regulator-compatible = "BUCK6";
+				regulator-name = "BUCK6";
 				regulator-min-microvolt = <800000>;
 				regulator-max-microvolt = <1400000>;
 				regulator-boot-on;
 				regulator-always-on;
 			};
 
-			ldo1_reg: regulator@6 {
-				reg = <6>;
-				regulator-compatible = "LDO1";
-				regulator-min-microvolt = <3000000>;
-				regulator-max-microvolt = <3300000>;
+			ldo1_reg: LDO1 {
+				regulator-name = "LDO1";
+				regulator-min-microvolt = <1600000>;
+				regulator-max-microvolt = <1900000>;
 				regulator-boot-on;
 				regulator-always-on;
 			};
 
-			ldo2_reg: regulator@7 {
-				reg = <7>;
-				regulator-compatible = "LDO2";
-				regulator-min-microvolt = <900000>;
+			ldo2_reg: LDO2 {
+				regulator-name = "LDO2";
+				regulator-min-microvolt = <800000>;
 				regulator-max-microvolt = <900000>;
 				regulator-boot-on;
 				regulator-always-on;
 			};
 
-			ldo3_reg: regulator@8 {
-				reg = <8>;
-				regulator-compatible = "LDO3";
+			ldo3_reg: LDO3 {
+				regulator-name = "LDO3";
 				regulator-min-microvolt = <1800000>;
 				regulator-max-microvolt = <3300000>;
 				regulator-boot-on;
 				regulator-always-on;
 			};
 
-			ldo4_reg: regulator@9 {
-				reg = <9>;
-				regulator-compatible = "LDO4";
+			ldo4_reg: LDO4 {
+				regulator-name = "LDO4";
 				regulator-min-microvolt = <900000>;
 				regulator-max-microvolt = <1800000>;
-				regulator-boot-on;
 				regulator-always-on;
 			};
 
-			ldo5_reg: regulator@12 {
-				reg = <12>;
-				regulator-compatible = "LDO5";
+			ldo5_reg: LDO5 {
+				regulator-name = "LDO5";
 				regulator-min-microvolt = <1800000>;
 				regulator-max-microvolt = <1800000>;
 				regulator-always-on;
 			};
 
-			ldo6_reg: regulator@11 {
-				reg = <11>;
-				regulator-compatible = "LDO6";
+			ldo6_reg: LDO6 {
+				regulator-name = "LDO6";
 				regulator-min-microvolt = <900000>;
 				regulator-max-microvolt = <1800000>;
 				regulator-boot-on;


### PR DESCRIPTION
PMIC configuration of AP20 differs from Variscite downstream
device-tree. Since PMIC is placed on SOM board, we need to align its
configuration in order to avoid undesired effects.