### PR TITLE
[leica/5.4-2.1.x-imx/dragonstaff]: arm64: dts: ap20: fix pmic interrupt level->edge

### DIFF
--- a/arch/arm64/boot/dts/freescale/ap20.dtsi
+++ b/arch/arm64/boot/dts/freescale/ap20.dtsi
@@ -218,7 +218,7 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&pinctrl_pmic>;
 		interrupt-parent = <&gpio2>;
-		interrupts = <8 IRQ_TYPE_LEVEL_LOW>;
+		interrupts = <8 IRQ_TYPE_EDGE_RISING>;
 		rohm,reset-snvs-powered;
 
 		regulators {


### PR DESCRIPTION
After commit e65b9b09d9a7 ("arm64: dts: ap20: align PMIC configuration with imx8mm-var-dart.dts") irq 87 is incorrectly configured as Level sensitive:

```
 $ cat /proc/interrupts:
87: 100001 0 0 0 gpio-mxc 8 Level bd718xx-irq

 $ dmesg
[ 66.258482] irq 87: nobody cared (try booting with the "irqpoll" option)
[ 66.265192] CPU: 0 PID: 0 Comm: swapper/0 Not tainted 5.4.134 #1
[ 66.271195] Hardware name: AP20-PT1 (DT)
[ 66.275115] Call trace:
[ 66.277569] dump_backtrace+0x0/0x140
[ 66.281230] show_stack+0x14/0x20
[ 66.284545] dump_stack+0xb4/0x110
[ 66.287946] __report_bad_irq+0x48/0xd4
[ 66.291781] note_interrupt+0x2c4/0x388
[ 66.295616] handle_irq_event_percpu+0x80/0x88
[ 66.300058] handle_irq_event+0x44/0xd8
[ 66.303892] handle_level_irq+0xb4/0x138
[ 66.307814] generic_handle_irq+0x24/0x38
[ 66.311825] mxc_gpio_irq_handler+0x48/0x138
[ 66.316094] mx3_gpio_irq_handler+0x80/0xe8
[ 66.320276] generic_handle_irq+0x24/0x38
[ 66.324283] __handle_domain_irq+0x60/0xb8
[ 66.328377] gic_handle_irq+0x5c/0x148
[ 66.332124] el1_irq+0xb8/0x180
[ 66.335267] cpuidle_enter_state+0x84/0x360
[ 66.339448] cpuidle_enter+0x34/0x48
[ 66.343022] call_cpuidle+0x18/0x38
[ 66.346509] do_idle+0x1e0/0x280
[ 66.349735] cpu_startup_entry+0x20/0x80
[ 66.353655] rest_init+0xd4/0xe0
[ 66.356883] arch_call_rest_init+0xc/0x14
[ 66.358946] rohm-bd718x7 0-004b: Failed to read IRQ status: -110
[ 66.360892] start_kernel+0x3f0/0x424
[ 66.370549] handlers:
[ 66.372824] [<00000000c6333c70>] irq_default_primary_handler threaded [<00000000de07d004>] regmap_irq_thread
[ 66.382653] Disabling IRQ #87
```

Hence, configure it back to edge.
