### PR TITLE
add ecspi support

### DIFF
--- a/arch/arm64/boot/dts/freescale/crocodile.dtsi
+++ b/arch/arm64/boot/dts/freescale/crocodile.dtsi
@@ -284,6 +284,49 @@
 	};
 };
 
+&ecspi3 {
+	fsl,spi-num-chipselects = <6>;
+	cs-gpios = <0>,
+		   <&gpio5 1 0>,
+		   <&gpio4 25 0>,
+		   <&gpio4 26 0>,
+		   <&gpio4 23 0>,
+		   <&gpio5 3 0>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_ecspi3>;
+	status = "okay";
+
+	imu1_accel@0 {
+		compatible = "spidev";
+		reg = <0>;
+	};
+
+	imu1_gyro@1 {
+		compatible = "spidev";
+		reg = <1>;
+	};
+
+	imu2_accel@2 {
+		compatible = "spidev";
+		reg = <2>;
+	};
+
+	imu2_gyro@3 {
+		compatible = "spidev";
+		reg = <3>;
+	};
+
+	imu3_accel@4 {
+		compatible = "spidev";
+		reg = <4>;
+	};
+
+	imu3_gyro@5 {
+		compatible = "spidev";
+		reg = <5>;
+	};
+};
+
 /* GNSS module */
 &uart1 {
 	pinctrl-names = "default";
@@ -438,6 +481,26 @@
 			MX8MM_IOMUXC_ECSPI2_MOSI_ECSPI2_MOSI	0x16
 			MX8MM_IOMUXC_ECSPI2_SCLK_ECSPI2_SCLK	0x1816
 			MX8MM_IOMUXC_ECSPI2_SS0_ECSPI2_SS0	0x0
+		>;
+	};
+
+	pinctrl_ecspi3: ecspi3grp {
+		fsl,pins = <
+			MX8MM_IOMUXC_UART1_TXD_ECSPI3_MOSI	0x16
+			MX8MM_IOMUXC_UART2_RXD_ECSPI3_MISO	0x16
+			MX8MM_IOMUXC_UART1_RXD_ECSPI3_SCLK	0x16
+			/* IMU_1_CS_ACC  */
+			MX8MM_IOMUXC_UART2_TXD_ECSPI3_SS0	0x0
+			/* IMU_1_CS_GYRO */
+			MX8MM_IOMUXC_SAI3_TXD_GPIO5_IO1	0x0
+			/* IMU_2_CS_ACC  */
+			MX8MM_IOMUXC_SAI2_TXC_GPIO4_IO25	0x0
+			/* IMU_2_CS_GYRO */
+			MX8MM_IOMUXC_SAI2_TXD0_GPIO4_IO26	0x0
+			/* IMU_3_CS_ACC  */
+			MX8MM_IOMUXC_SAI2_RXD0_GPIO4_IO23	0x0
+			/* IMU_3_CS_GYRO */
+			MX8MM_IOMUXC_SPDIF_TX_GPIO5_IO3	0x0
 		>;
 	};
 


### PR DESCRIPTION
All three ECSPI engines are in use:
 - ECSPI1 - Inclinometer
 - ECSPI2 - UHF
 - ECSPI3 - IMU

"spidev" approach showed good results on proto boards.

