### PR TITLE
arm64: dts: crocodile: align PMIC configuration with imx8mm-evk Rev. B

### DIFF
--- a/arch/arm64/boot/dts/freescale/crocodile.dtsi
+++ b/arch/arm64/boot/dts/freescale/crocodile.dtsi
@@ -136,7 +136,7 @@
 				regulator-boot-on;
 				regulator-always-on;
 				regulator-ramp-delay = <3125>;
-				nxp,dvs-run-voltage = <850000>;
+				nxp,dvs-run-voltage = <820000>;
 				nxp,dvs-standby-voltage = <800000>;
 			};
 


### PR DESCRIPTION
Align with PMIC configuration in `imx8mm-evk.dtsi` from linux-fslc.
[7305370](https://github.com/Freescale/linux-fslc/commit/73053707fc2b93ff5a1b4b3dad5ca144e34acda4)