### PR TITLE
arm64: dtsi: add support for rtc rx8130

### DIFF
--- a/arch/arm64/boot/dts/freescale/crocodile.dtsi
+++ b/arch/arm64/boot/dts/freescale/crocodile.dtsi
@@ -246,6 +246,12 @@
 		compatible = "ti,tmp112";
 		reg = <0x48>;
 	};
+
+	rtc@32 {
+		compatible = "epson,rx8130";
+		reg = <0x32>;
+		aux-voltage-chargeable = <0>;
+	};
 };
 
 &i2c4 {


### PR DESCRIPTION
Added the rtc rx8130 in the device tree.
We use the generic driver for ds1307 that is also compatible with our
rx8130. The EPSON driver is too old and uses deprecated functions.

Signed-off-by: massimo toscanelli <massimo.toscanelli@leica-geosystems.com>