### PR TITLE
arm64:dts: crocodile: decrease I2C clocks

### DIFF
--- a/arch/arm64/boot/dts/freescale/crocodile.dtsi
+++ b/arch/arm64/boot/dts/freescale/crocodile.dtsi
@@ -237,7 +237,7 @@
 };
 
 &i2c3 {
-	clock-frequency = <400000>;
+	clock-frequency = <100000>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_i2c3>;
 	status = "okay";
@@ -255,7 +255,7 @@
 };
 
 &i2c4 {
-	clock-frequency = <400000>;
+	clock-frequency = <384000>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_i2c4>;
 	status = "okay";


### PR DESCRIPTION
According to Mask Set Errata IMX8MM_0N87W, the clock frequency must be
set to 384kHz to fulfil the requirement of a low period of 1.3us.

Decrease clock frequency of I2C3 to 100kHz (since we do not have timing
critical communications on this interface) and set it to the suggested
value of 384kHz for I2C4.