### PR TITLE
arm64: dts: crocodile: add wakeup rtc

### DIFF
--- a/arch/arm64/boot/dts/freescale/crocodile.dtsi
+++ b/arch/arm64/boot/dts/freescale/crocodile.dtsi
@@ -251,6 +251,7 @@
 		compatible = "epson,rx8130";
 		reg = <0x32>;
 		aux-voltage-chargeable = <0>;
+		wakeup-source;
 	};
 };
 


### PR DESCRIPTION
The product managment confirmed the usage of the RTC wakeup interrupt, so
we need to include it in the device tree.

Signed-off-by: massimo toscanelli <massimo.toscanelli@leica-geosystems.com>