### PR TITLE
arm64: dts: ap20-pt1-5: add support for AP20-PT1.5

### DIFF
--- a/arch/arm64/boot/dts/freescale/ap20-pt1-5.dts
+++ b/arch/arm64/boot/dts/freescale/ap20-pt1-5.dts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2021 Leica Geosystems AG
+ */
+
+/dts-v1/;
+
+#include "ap20.dtsi"
+
+/ {
+	model = "AP20-PT1.5";
+};
+
+&fec1 {
+	/*
+	 * disable reset gpio since PHY is not detected anymore after a reset.
+	 */
+	/delete-property/ phy-reset-gpios;
+	/delete-property/ phy-reset-duration;
+};


### PR DESCRIPTION
Introduce new device tree for PT1.5 based on `ap20.dtsi`.

Signed-off-by: massimo toscanelli <massimo.toscanelli@leica-geosystems.com>