### PR TITLE
Scl3300 driver only

### DIFF
--- a/Documentation/devicetree/bindings/iio/accel/murata,sca3300.yaml
+++ b/Documentation/devicetree/bindings/iio/accel/murata,sca3300.yaml
@@ -17,7 +17,7 @@ properties:
   compatible:
     enum:
       - murata,sca3300
-
+      - murata,scl3300
   reg:
     maxItems: 1
 


### PR DESCRIPTION
the existing driver support sca3300 only, the out put is accel vaule only,
The change add support for scl3300.
add out put of inclinaton value. in_incli_x_raw in_incli_y_raw in_incli_z_raw and scale.
add in_incli_en to enable/disable inclination output.
add in_op_mode to get/set the chip operation modes.
add in_accel_op_mode_available to get avalilable operation modes.

root@crocodile:/sys/bus/iio/devices/iio:device1# ls -la
total 0
drwxr-xr-x 7 root root 0 Dec 2 06:35 .
drwxr-xr-x 5 root root 0 Dec 2 06:35 ..
drwxr-xr-x 2 root root 0 Dec 2 06:37 buffer
drwxr-xr-x 2 root root 0 Dec 2 06:37 buffer0
-rw-r--r-- 1 root root 4096 Dec 2 06:37 current_timestamp_clock
-r--r--r-- 1 root root 4096 Dec 2 06:37 dev
-rw-r--r-- 1 root root 4096 Dec 2 06:37 in_accel_filter_low_pass_3db_frequency
-r--r--r-- 1 root root 4096 Dec 2 06:37 in_accel_filter_low_pass_3db_frequency_available
-rw-r--r-- 1 root root 4096 Dec 2 06:37 in_accel_scale
-r--r--r-- 1 root root 4096 Dec 2 06:37 in_accel_scale_available
-rw-r--r-- 1 root root 4096 Dec 2 06:37 in_accel_x_raw
-rw-r--r-- 1 root root 4096 Dec 2 06:37 in_accel_y_raw
-rw-r--r-- 1 root root 4096 Dec 2 06:37 in_accel_z_raw
-rw-r--r-- 1 root root 4096 Dec 2 06:37 in_incli_en
-rw-r--r-- 1 root root 4096 Dec 2 06:37 in_incli_filter_low_pass_3db_frequency
-r--r--r-- 1 root root 4096 Dec 2 06:37 in_incli_filter_low_pass_3db_frequency_available
-rw-r--r-- 1 root root 4096 Dec 2 06:37 in_incli_scale
-r--r--r-- 1 root root 4096 Dec 2 06:37 in_incli_scale_available
-rw-r--r-- 1 root root 4096 Dec 2 06:37 in_incli_x_raw
-rw-r--r-- 1 root root 4096 Dec 2 06:37 in_incli_y_raw
-rw-r--r-- 1 root root 4096 Dec 2 06:37 in_incli_z_raw
-rw-r--r-- 1 root root 4096 Dec 2 06:37 in_temp_raw
-r--r--r-- 1 root root 4096 Dec 2 06:37 name
lrwxrwxrwx 1 root root 0 Dec 2 06:37 of_node ->