### PR TITLE
arm64: dts: crocodile: remove DMA for console

### DIFF
--- a/arch/arm64/boot/dts/freescale/crocodile.dtsi
+++ b/arch/arm64/boot/dts/freescale/crocodile.dtsi
@@ -362,6 +362,8 @@
 &uart2 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_uart2>;
+	dmas = <&sdma1 24 4 0>, <&sdma1 25 4 0>;
+	dma-names = "rx", "tx";
 	uart-has-rtscts;
 	status = "okay";
 };
@@ -370,6 +372,8 @@
 &uart3 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_uart3>;
+	/delete-property/ dmas;
+	/delete-property/ dma-names;
 	status = "okay";
 };
 


### PR DESCRIPTION
Operations on kernel console needs to be atomic - that's why `uart2`
in imx8mm.dtsi does not provide any DMA-properties, since usually this
UART is used as kernel console.
On crocodile `uart3` is used as console.

Remove DMA-properties from node `uart3` and add the specific ones to
`uart2` (which are missing in imx8mm.dtsi).