### PR TITLE
Crocodile magn alwayson

### DIFF
--- a/drivers/iio/magnetometer/st_magn_core.c
+++ b/drivers/iio/magnetometer/st_magn_core.c
@@ -563,9 +563,12 @@ static int st_magn_write_raw(struct iio_dev *indio_dev,
 static ST_SENSORS_DEV_ATTR_SAMP_FREQ_AVAIL();
 static ST_SENSORS_DEV_ATTR_SCALE_AVAIL(in_magn_scale_available);
 
+static ST_SENSORS_DEV_ATTR_ALWAYS_ON();
+
 static struct attribute *st_magn_attributes[] = {
 	&iio_dev_attr_sampling_frequency_available.dev_attr.attr,
 	&iio_dev_attr_in_magn_scale_available.dev_attr.attr,
+	&iio_dev_attr_always_on.dev_attr.attr,
 	NULL,
 };
 

--- a/include/linux/iio/common/st_sensors.h
+++ b/include/linux/iio/common/st_sensors.h
@@ -82,6 +82,10 @@
 		IIO_DEVICE_ATTR(name, S_IRUGO, \
 			st_sensors_sysfs_scale_avail, NULL , 0);
 
+#define ST_SENSORS_DEV_ATTR_ALWAYS_ON() \
+		IIO_DEVICE_ATTR(always_on, 0644, st_sensors_sysfs_show_always_on, \
+				st_sensors_sysfs_store_always_on, 0)
+
 struct st_sensor_odr_avl {
 	unsigned int hz;
 	u8 value;
@@ -229,6 +233,7 @@ struct st_sensor_settings {
  * @vdd_io: Pointer to sensor's Vdd-IO power supply
  * @regmap: Pointer to specific sensor regmap configuration.
  * @enabled: Status of the sensor (false->off, true->on).
+ * @always_on: Flag to keep the sensor always enabled (false->off, true->on).
  * @odr: Output data rate of the sensor [Hz].
  * num_data_channels: Number of data channels used in buffer.
  * @drdy_int_pin: Redirect DRDY on pin 1 (1) or pin 2 (2).
@@ -250,6 +255,7 @@ struct st_sensor_data {
 	struct regmap *regmap;
 
 	bool enabled;
+	bool always_on;
 
 	unsigned int odr;
 	unsigned int num_data_channels;
@@ -326,6 +332,14 @@ ssize_t st_sensors_sysfs_scale_avail(struct device *dev,
 				struct device_attribute *attr, char *buf);
 
 void st_sensors_dev_name_probe(struct device *dev, char *name, int len);
+
+ssize_t st_sensors_sysfs_show_always_on(struct device *dev,
+					struct device_attribute *attr,
+					char *buf);
+
+ssize_t st_sensors_sysfs_store_always_on(struct device *dev,
+					 struct device_attribute *attr,
+					 const char *buf, size_t count);
 
 /* Accelerometer */
 const struct st_sensor_settings *st_accel_get_settings(const char *name);


### PR DESCRIPTION
    The st_sensors_read_info_raw() implementation allows to get raw data
    from st_sensors, enabling and disabling the device at every read.
    This leads to delays in data access, because, after every enable, we
    need to wait the hardware to be ready.

    Introducing the 'alwayson' flag in (st_sensor_data) and the
    correspondent sysfs attribute, we allow the user to keep the device
    always enabled. In this way, every data access to the device can be
    performed with no delays.