### PR TITLE
arm64: dts: ap20: enable pull-down resistors for pad SAI3_RXFS

### DIFF
--- a/arch/arm64/boot/dts/freescale/ap20.dtsi
+++ b/arch/arm64/boot/dts/freescale/ap20.dtsi
@@ -202,7 +202,7 @@
 		
 		pinctrl_gpio_keys: gpio-keysgrp {
 			fsl,pins = <
-				MX8MM_IOMUXC_SAI3_RXFS_GPIO4_IO28		0x00
+				MX8MM_IOMUXC_SAI3_RXFS_GPIO4_IO28		0x100
 			>;
 		};
 


### PR DESCRIPTION
In case the connected port-pin on MCU is not initialized, we need to
prevent from a floating signal.
Enable pull-down resistors for pad SAI3_RXFS (GPIO4_IO28) in order to
have a defined signal - the active state of "Power-Off-Signal" is high.