### PR TITLE
usb: chipidea: add "ci-disable-lpm"

### DIFF
--- a/Documentation/devicetree/bindings/usb/ci-hdrc-usb2.txt
+++ b/Documentation/devicetree/bindings/usb/ci-hdrc-usb2.txt
@@ -90,6 +90,7 @@ Optional properties:
   case, the "idle" state needs to pull down the data and strobe pin
   and the "active" state needs to pull up the strobe pin.
 - pinctrl-n: alternate pin modes
+- ci-disable-lpm: Some chipidea hardware need to disable low power mode
 
 i.mx specific properties
 - fsl,usbmisc: phandler of non-core register device, with one

--- a/arch/arm64/boot/dts/freescale/crocodile.dtsi
+++ b/arch/arm64/boot/dts/freescale/crocodile.dtsi
@@ -433,6 +433,7 @@
 	disable-over-current;
 	picophy,pre-emp-curr-control = <3>;
 	picophy,dc-vol-level-adjust = <7>;
+	ci-disable-lpm;
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/freescale/crocodile.dtsi
+++ b/arch/arm64/boot/dts/freescale/crocodile.dtsi
@@ -431,8 +431,8 @@
 &usbotg1 {
 	dr_mode = "otg";
 	disable-over-current;
-	picophy,pre-emp-curr-control = <3>;
-	picophy,dc-vol-level-adjust = <7>;
+	samsung,picophy-pre-emp-curr-control = <3>;
+	samsung,picophy-dc-vol-level-adjust = <7>;
 	ci-disable-lpm;
 	status = "okay";
 };

--- a/drivers/usb/chipidea/ci_hdrc_imx.c
+++ b/drivers/usb/chipidea/ci_hdrc_imx.c
@@ -447,6 +447,11 @@ static int ci_hdrc_imx_probe(struct platform_device *pdev)
 	if (pdata.flags & CI_HDRC_SUPPORTS_RUNTIME_PM)
 		data->supports_runtime_pm = true;
 
+	if (of_find_property(np, "ci-disable-lpm", NULL)) {
+		data->supports_runtime_pm = false;
+		pdata.flags &= ~CI_HDRC_SUPPORTS_RUNTIME_PM;
+	}
+
 	ret = imx_usbmisc_init(data->usbmisc_data);
 	if (ret) {
 		dev_err(dev, "usbmisc init failed, ret=%d\n", ret);


### PR DESCRIPTION
If suspended, the USB controller of the IMX8MM cannot wake up
connecting a cable. Therefore, we disable the low power mode for the
USB controller.

We also fix the USB picophy parameters (in crocodile.dtsi), that need to be coherent with the new
samsung-based definitions.

Signed-off-by: Massimo Toscanelli <massimo.toscanelli@leica-geosystems.com>