### PR TITLE
arm64: dtsi: crocodile: Disable magnetometer pull resistors

### DIFF
--- a/arch/arm64/boot/dts/freescale/crocodile.dtsi
+++ b/arch/arm64/boot/dts/freescale/crocodile.dtsi
@@ -729,7 +729,7 @@
 
 	pinctrl_iis2mdc: iis2mdcgrp {
 		fsl,pins = <
-			CROCODILE_MAG_DRDY		0x140
+			CROCODILE_MAG_DRDY		0x40
 		>;
 	};
 


### PR DESCRIPTION
once the measurement has been performed, the DRDY pin is set to high,
and clear after read the measurement the data, if pull is enable, sometimes
the pin can not clean by magnetometer, it cause no rising edge even the
data is ready, then the bufferd reading will be timeout.

Signed-off-by: LI Qingwu <Qing-wu.Li@leica-geosystems.com.cn>