### PR TITLE
arm64: dts: crocodile: enable SNVS power key

### DIFF
--- a/arch/arm64/boot/dts/freescale/crocodile.dtsi
+++ b/arch/arm64/boot/dts/freescale/crocodile.dtsi
@@ -416,6 +416,10 @@
 	status = "okay";
 };
 
+&snvs_pwrkey {
+	status = "okay";
+};
+
 &gpio1 {
 	gpio-line-names =
 		"",


### PR DESCRIPTION
In order to shutdown properly, we use the signal from MCU connected to
ONOFF pad. If the signal is set by MCU shorter than 5 seconds, the
interrupt set_pwr_off_irq is raised and input event KEY_POWER is sent.

Refer to https://github.com/hexagon-geo-surv/linux-leica/commit/2d5305a54b955396366e915586eddd0f3a1b5184