### PR TITLE
arm64: dts: beluga: enable uart3

### DIFF
--- a/arch/arm64/boot/dts/freescale/beluga.dts
+++ b/arch/arm64/boot/dts/freescale/beluga.dts
@@ -399,6 +399,18 @@
 	status = "okay";
 };
 
+&ecspi2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_ecspi2>;
+	cs-gpios = <0>;
+	status = "okay";
+
+	spidev0: spi@0 {
+		reg = <0>;
+		compatible = "lgs-crocodile,spi";
+	};
+};
+
 &iomuxc {
 	pinctrl_eqos: eqosgrp {
 		fsl,pins = <
@@ -626,4 +638,15 @@
 			MX8MP_IOMUXC_GPIO1_IO02__WDOG1_WDOG_B	0x166
 		>;
 	};
+
+	pinctrl_ecspi2: ecspi2grp {
+		fsl,pins = <
+			MX8MP_IOMUXC_ECSPI2_SCLK__ECSPI2_SCLK		0x82
+			MX8MP_IOMUXC_ECSPI2_SCLK__ECSPI2_SCLK		0x82
+			MX8MP_IOMUXC_ECSPI2_MOSI__ECSPI2_MOSI		0x82
+			MX8MP_IOMUXC_ECSPI2_MISO__ECSPI2_MISO		0x82
+			MX8MP_IOMUXC_ECSPI2_SS0__ECSPI2_SS0			0x82
+		>;
+	};
+
 };

--- a/arch/arm64/boot/dts/freescale/beluga.dts
+++ b/arch/arm64/boot/dts/freescale/beluga.dts
@@ -346,6 +346,12 @@
 	status = "okay";
 };
 
+&uart3 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart3>;
+	status = "okay";
+};
+
 &usb3_phy1 {
 	status = "okay";
 };
@@ -509,6 +515,13 @@
 		fsl,pins = <
 			MX8MP_IOMUXC_UART2_RXD__UART2_DCE_RX	0x49
 			MX8MP_IOMUXC_UART2_TXD__UART2_DCE_TX	0x49
+		>;
+	};
+
+	pinctrl_uart3: uart3grp {
+		fsl,pins = <
+			MX8MP_IOMUXC_ECSPI1_SCLK__UART3_DCE_RX	0x49
+			MX8MP_IOMUXC_ECSPI1_MOSI__UART3_DCE_TX	0x49
 		>;
 	};
 

--- a/drivers/spi/spidev.c
+++ b/drivers/spi/spidev.c
@@ -703,6 +703,7 @@ static const struct of_device_id spidev_dt_ids[] = {
 	{ .compatible = "menlo,m53cpld" },
 	{ .compatible = "cisco,spi-petra" },
 	{ .compatible = "micron,spi-authenta" },
+	{ .compatible = "lgs-crocodile,spi" },
 	{},
 };
 MODULE_DEVICE_TABLE(of, spidev_dt_ids);


### PR DESCRIPTION
UART3 connected to expansion connector on beluga EVK,
Enable the port to connect UART devices.

Signed-off-by: LI Qingwu <Qing-wu.Li@leica-geosystems.com.cn>