### PR TITLE
PCI: add class quirk for Microchip DG0756 to fix BAR assignment

### DIFF
--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -5826,6 +5826,14 @@ static void apex_pci_fixup_class(struct pci_dev *pdev)
 DECLARE_PCI_FIXUP_CLASS_HEADER(0x1ac1, 0x089a,
 			       PCI_CLASS_NOT_DEFINED, 8, apex_pci_fixup_class);
 
+static void mpf_pci_fixup_class(struct pci_dev *pdev)
+{
+	pci_info(pdev, "FIXUP MPF class\n");
+	pdev->class = (PCI_CLASS_SYSTEM_OTHER << 8) | pdev->class;
+}
+DECLARE_PCI_FIXUP_CLASS_HEADER(0x11aa, 0x1556,
+				PCI_CLASS_NOT_DEFINED, 8, mpf_pci_fixup_class);
+
 /*
  * Pericom PI7C9X2G404/PI7C9X2G304/PI7C9X2G303 switch erratum E5 -
  * ACS P2P Request Redirect is not functional


### PR DESCRIPTION
This patch is required to run the PolarFire FPGA demo on non-x86 platforms (like the i.MX8MP). If the FPGA designer chooses a reasonable value for the PCI class code, this correction is not required for the final PCIe FPGA image.
So, I'm not sure if you want to apply this patch to your kernel or not.
