### PR TITLE
arm64: dts: crocodile: uart2: set IMX8MM_SYS_PLL1_80M parent of uart2 clock

### DIFF
--- a/arch/arm64/boot/dts/freescale/crocodile.dtsi
+++ b/arch/arm64/boot/dts/freescale/crocodile.dtsi
@@ -319,6 +319,8 @@
 	pinctrl-0 = <&pinctrl_uart2>;
 	dmas = <&sdma1 24 4 0>, <&sdma1 25 4 0>;
 	dma-names = "rx", "tx";
+	assigned-clocks = <&clk IMX8MM_CLK_UART2>;
+	assigned-clock-parents = <&clk IMX8MM_SYS_PLL1_80M>;
 	uart-has-rtscts;
 	status = "okay";
 };


### PR DESCRIPTION
The UART baudrate in the Bluetooth firmware of uBlox BT/WLAN module
MAYA-W161 on PT1 is set to 3M (while it is 115200 on MAYA-W160).

Without setting IMX8MM_SYS_PLL1_80M as parent, the baudrate of 3M is too
high for the default clock input and the communication with the module
fails.
As baudrate 115200 for MAYA-W160 can also be achieved with
IMX8MM_SYS_PLL1_80M this goes into `crocodile.dtsi`.