### PR TITLE
arm64: dts: ap20-pt1-5: restore ap20-pt1-5.

### DIFF
--- a/arch/arm64/boot/dts/freescale/ap20-pt1-5.dts
+++ b/arch/arm64/boot/dts/freescale/ap20-pt1-5.dts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2021 Leica Geosystems AG
+ */
+
+/dts-v1/;
+
+#include "ap20.dtsi"
+
+/ {
+       model = "AP20-PT1.5";
+};
+
+&fec1 {
+       /*
+        * disable reset gpio since PHY is not detected anymore after a reset.
+        */
+       /delete-property/ phy-reset-gpios;
+       /delete-property/ phy-reset-duration;
+};


### PR DESCRIPTION
partly revert commit `7fd8785cf68df835684247f61dabb4f6580d118d`

1. When `trigger_update`, in the first step, a new updater image will be updated on board and set `swu=1` to reboot.
2. The new updater image will call `bootm ${initrd_addr}#${fit_config}` to boot up. but now the fit_config was an older version, it point to `AP20-PT1-5.dtb`. And the updater image is initramfs, it will contain device tree by itself when finding `AP20-PT1-5.dtb`.
So restore `AP20-PT1-5.dtb` here.