### PR TITLE
arm64: dts: crocodile: enable GPIO4 and GPIO5

### DIFF
--- a/arch/arm64/boot/dts/freescale/crocodile-rev-b.dts
+++ b/arch/arm64/boot/dts/freescale/crocodile-rev-b.dts
@@ -141,6 +141,7 @@
 };
 
 &gpio4 {
+	status = "okay";
 	gpio-line-names =
 		"DBG_ENET_WOL",
 		"DBG_ENET_INT",
@@ -157,6 +158,7 @@
 };
 
 &gpio5 {
+	status = "okay";
 	gpio-line-names =
 		"", "",
 		"LTE_FST_SHDN";


### PR DESCRIPTION
The crocodile.dtsi should reflect the final board - where access to
GPIO4 and GPIO5 is dedicated to M4 - therefore both nodes are disabled.
In board revision B, all GPIOs are only accessed by A53 - enable them.