### PR TITLE
arm64: dts: crocodile: uart4: remove dma properties on UART to MCU

### DIFF
--- a/arch/arm64/boot/dts/freescale/crocodile.dtsi
+++ b/arch/arm64/boot/dts/freescale/crocodile.dtsi
@@ -318,6 +318,8 @@
 &uart4 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_uart4>;
+	/delete-property/ dmas;
+	/delete-property/ dma-names;
 	status = "okay";
 };
 


### PR DESCRIPTION
when both uart3 and uart4 are enabled/tagged in the devicetree for loading during SPL, the debug-serial becomes unusable/silent and SPL hangs/runs into a watchdog reset.  removing the dma properties solves this.

Signed-off-by: Johannes Schneider <johannes.schneider@leica-geosystems.com>