### PR TITLE
arm64: dts: beluga: Enable type C port USB1

### DIFF
--- a/arch/arm64/boot/dts/freescale/beluga.dts
+++ b/arch/arm64/boot/dts/freescale/beluga.dts
@@ -389,6 +389,20 @@
 	status = "okay";
 };
 
+/* USB1 - Type C PORT 1 */
+&usb3_phy0 {
+       status = "okay";
+};
+
+&usb3_0 {
+       status = "okay";
+};
+
+&usb_dwc3_0 {
+       dr_mode = "otg";
+       status = "okay";
+};
+
 &usb3_phy1 {
 	status = "okay";
 };


### PR DESCRIPTION
Enable the USB1, the type c PORT1 connector.
For RNDIS and Mass storage as peripheral.

Signed-off-by: LI Qingwu <Qing-wu.Li@leica-geosystems.com.cn>