### PR TITLE
drivers: spi: add leica compatible entry from dts

### DIFF
--- a/drivers/spi/spidev.c
+++ b/drivers/spi/spidev.c
@@ -696,6 +696,7 @@ static const struct of_device_id spidev_dt_ids[] = {
 	{ .compatible = "menlo,m53cpld" },
 	{ .compatible = "cisco,spi-petra" },
 	{ .compatible = "micron,spi-authenta" },
+	{ .compatible = "leica,spidev" },
 	{},
 };
 MODULE_DEVICE_TABLE(of, spidev_dt_ids);


### PR DESCRIPTION
Add DT compatible string to probe and get spi device nodes.

Signed-off-by: Mamta Shukla <mamta.shukla@leica-geosystems.com>