### PR TITLE
Revert "arm64: dts: crocodile: uart4: set pullups/downs on UART to MCU"

### DIFF
--- a/arch/arm64/boot/dts/freescale/crocodile.dtsi
+++ b/arch/arm64/boot/dts/freescale/crocodile.dtsi
@@ -314,7 +314,7 @@
 	status = "okay";
 };
 
-/* MCU */
+/* PP4 */
 &uart4 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_uart4>;
@@ -673,8 +673,8 @@
 
 	pinctrl_uart4: uart4grp {
 		fsl,pins = <
-			CROCODILE_IMX8_UART4_RXD	0x0
-			CROCODILE_IMX8_UART4_TXD	0x170
+			CROCODILE_IMX8_UART4_RXD	0x140
+			CROCODILE_IMX8_UART4_TXD	0x140
 		>;
 	};
 


### PR DESCRIPTION
This reverts commit ab7abfe71812f7fa766ee4d20504cd09fc25d37a.

Enabling open-drain for UART4 TX decreases the high voltage level, leading to an unstable connection. Further, there is no reason to enable it, as the connection was stable before, when open-drain was disabled.