### PR TITLE
arm64: dts: crocodile-rev-b: add m4 support

### DIFF
--- a/arch/arm64/boot/dts/freescale/crocodile-rev-b.dts
+++ b/arch/arm64/boot/dts/freescale/crocodile-rev-b.dts
@@ -7,6 +7,7 @@
 
 #include "crocodile-pinmap-rev-b.h"
 #include "crocodile.dtsi"
+#include "crocodile-rpmsg.dtsi"
 
 / {
 	model = "Crocodile-Rev-B";


### PR DESCRIPTION
Add support to communication with Cortex M4 processor in crocodile-rev-b boards.

This allows to load "dummy" firmwares that do not use any external gpio, but just rpmsg communication for testing purposes.

Signed-off-by: Massimo Toscanelli <massimo.toscanelli@leica-geosystems.com>