### PR TITLE
arm64: dts: crocodile: pmic: set min/max voltages

### DIFF
--- a/arch/arm64/boot/dts/freescale/crocodile.dtsi
+++ b/arch/arm64/boot/dts/freescale/crocodile.dtsi
@@ -139,94 +139,104 @@
 		interrupts = <3 IRQ_TYPE_LEVEL_LOW>;
 
 		regulators {
+			// VDD_SOC_0V8
 			buck1_reg: BUCK1 {
 				regulator-name = "BUCK1";
-				regulator-min-microvolt = <600000>;
-				regulator-max-microvolt = <2187500>;
+				regulator-min-microvolt = <780000>;
+				regulator-max-microvolt = <900000>;
 				regulator-boot-on;
 				regulator-always-on;
 				regulator-ramp-delay = <3125>;
-				nxp,dvs-run-voltage = <820000>;
 				nxp,dvs-standby-voltage = <800000>;
 			};
 
+			// VDD_ARM_0V9
 			buck2_reg: BUCK2 {
 				regulator-name = "BUCK2";
-				regulator-min-microvolt = <600000>;
-				regulator-max-microvolt = <2187500>;
+				regulator-min-microvolt = <805000>;
+				regulator-max-microvolt = <1050000>;
 				regulator-boot-on;
 				regulator-always-on;
 				regulator-ramp-delay = <3125>;
 			};
 
+			// VDD_DRAM&PU_0V9
 			buck3_reg: BUCK3 {
 				regulator-name = "BUCK3";
-				regulator-min-microvolt = <600000>;
-				regulator-max-microvolt = <2187500>;
+				regulator-min-microvolt = <805000>;
+				regulator-max-microvolt = <1000000>;
 				regulator-boot-on;
 				regulator-always-on;
 			};
 
+			// VDD_3V3/NVCC_3V3
 			buck4_reg: BUCK4 {
 				regulator-name = "BUCK4";
-				regulator-min-microvolt = <600000>;
-				regulator-max-microvolt = <3400000>;
+				regulator-min-microvolt = <3000000>;
+				regulator-max-microvolt = <3600000>;
 				regulator-boot-on;
 				regulator-always-on;
 			};
 
+			// VDD_1V8/NVCC_1V8
 			buck5_reg: BUCK5 {
 				regulator-name = "BUCK5";
-				regulator-min-microvolt = <600000>;
-				regulator-max-microvolt = <3400000>;
+				regulator-min-microvolt = <1650000>;
+				regulator-max-microvolt = <1950000>;
 				regulator-boot-on;
 				regulator-always-on;
 			};
 
+			// NVCC_DRAM_1V1
 			buck6_reg: BUCK6 {
 				regulator-name = "BUCK6";
-				regulator-min-microvolt = <600000>;
-				regulator-max-microvolt = <3400000>;
+				regulator-min-microvolt = <1060000>;
+				regulator-max-microvolt = <1140000>;
 				regulator-boot-on;
 				regulator-always-on;
 			};
 
+			// NVCC_SNVS_1V8
 			ldo1_reg: LDO1 {
 				regulator-name = "LDO1";
-				regulator-min-microvolt = <1600000>;
-				regulator-max-microvolt = <3300000>;
+				regulator-min-microvolt = <1620000>;
+				regulator-max-microvolt = <1980000>;
 				regulator-boot-on;
 				regulator-always-on;
 			};
 
+			// VDD_SNVS_0V8
 			ldo2_reg: LDO2 {
 				regulator-name = "LDO2";
-				regulator-min-microvolt = <800000>;
-				regulator-max-microvolt = <1150000>;
+				regulator-min-microvolt = <760000>;
+				regulator-max-microvolt = <900000>;
 				regulator-boot-on;
 				regulator-always-on;
 			};
 
+			// VDDA_1V8
 			ldo3_reg: LDO3 {
 				regulator-name = "LDO3";
-				regulator-min-microvolt = <800000>;
-				regulator-max-microvolt = <3300000>;
+				regulator-min-microvolt = <1710000>;
+				regulator-max-microvolt = <1890000>;
 				regulator-boot-on;
 				regulator-always-on;
 			};
 
+			// VDD_PHY_0V9
 			ldo4_reg: LDO4 {
 				regulator-name = "LDO4";
-				regulator-min-microvolt = <800000>;
-				regulator-max-microvolt = <3300000>;
+				regulator-min-microvolt = <855000>;
+				regulator-max-microvolt = <1000000>;
 				regulator-boot-on;
 				regulator-always-on;
 			};
 
+			// NVCC_SD2
 			ldo5_reg: LDO5 {
 				regulator-name = "LDO5";
-				regulator-min-microvolt = <1800000>;
-				regulator-max-microvolt = <3300000>;
+				regulator-min-microvolt = <1650000>;
+				regulator-max-microvolt = <3600000>;
 			};
 		};
 	};

--- a/arch/arm64/boot/dts/freescale/crocodile.dtsi
+++ b/arch/arm64/boot/dts/freescale/crocodile.dtsi
@@ -85,6 +85,11 @@
 	cpu-supply = <&buck2_reg>;
 };
 
+&a53_opp_table {
+	       /delete-node/ opp-1600000000;
+	       /delete-node/ opp-1800000000;
+};
+
 &ddrc {
 	operating-points-v2 = <&ddrc_opp_table>;
 


### PR DESCRIPTION
according to the power (sequence) table found in the baseboard schematic (of rev-b)

"stumbled" over this while upstreaming the imx8mm-revb.dts

applied the changes to barebox too, system seems to boot just fine, and hold up under load(?)
$> md5sum /dev/zero & # times 4
$> cat /proc/loadavg 
4.20 4.20 3.61 5/148 519
=> is there "an appropriate" way to verify those limits?

NOTE: not quite sure about the limits of LDO5 = NVCC_SD2 though...
-> please tripple check (-:
