### PR TITLE
ARM: dts: leica-krea: align with FPGA image 1034307

### DIFF
--- a/arch/arm/boot/dts/leica_krea.dts
+++ b/arch/arm/boot/dts/leica_krea.dts
@@ -198,13 +198,43 @@
 			interrupt-parent = <&intc>;
 	};
 
+	/* UIO access: Leica Frame Camera - CAM0 Histogram
+	*/
+	leicaUioSIHistogramCamera0: leicaUioKAFC_HIST0@0 {
+			compatible = "leica-uio";
+			status = "okay";
+			reg = < 0xFF280000 0x00040000 >;
+			interrupts = < 0 60 1 >;
+			interrupt-parent = <&intc>;
+	};
+
+	/* UIO access: Leica Frame Camera - CAM1 Histogram
+	*/
+	leicaUioSIHistogramCamera1: leicaUioKAFC_HIST1@0 {
+			compatible = "leica-uio";
+			status = "okay";
+			reg = < 0xFF280000 0x00040000 >;
+			interrupts = < 0 61 1 >;
+			interrupt-parent = <&intc>;
+	};
+
+	/* UIO access: Leica Frame Camera - CAM2 Histogram
+	*/
+	leicaUioSIHistogramCamera2: leicaUioKAFC_HIST2@0 {
+			compatible = "leica-uio";
+			status = "okay";
+			reg = < 0xFF280000 0x00040000 >;
+			interrupts = < 0 62 1 >;
+			interrupt-parent = <&intc>;
+	};
+
 	/* UIO access: Leica Frame Camera - CAM0 Framewriter 1
 	*/
 	leicaUioSIFramewriter1Camera0: leicaUioKAFC_FW10@0 {
 			compatible = "leica-uio";
 			status = "okay";
 			reg = < 0xFF280000 0x00040000 >;
-			interrupts = < 0 60 1 >;
+			interrupts = < 0 63 1 >;
 			interrupt-parent = <&intc>;
 	};
 
@@ -214,7 +244,7 @@
 			compatible = "leica-uio";
 			status = "okay";
 			reg = < 0xFF280000 0x00200000 >;
-			interrupts = < 0 63 1 >;
+			interrupts = < 0 64 1 >;
 			interrupt-parent = <&intc>;
 	};
 


### PR DESCRIPTION
FGPA image version 1.0.1034307 implements Iride Light (Auto Exposure Prototoype): some IP blocks got changed.

Heanse, align the DTS to provide correct HW description.

This partially reverts commit 604682b6f17 ("ARM: dts: leica-krea: align with FPGA image 1022315").