### PR TITLE
arm64: dts: beluga: move support for UART3 to overlay

### DIFF
--- a/arch/arm64/boot/dts/freescale/beluga-uart3.dts
+++ b/arch/arm64/boot/dts/freescale/beluga-uart3.dts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/*
+ * Copyright (C) 2023 Leica Geosystems AG
+ */
+
+#include "imx8mp-pinfunc.h"
+
+/dts-v1/;
+/plugin/;
+
+&uart3 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart3>;
+	status = "okay";
+};
+
+&iomuxc {
+	pinctrl_uart3: uart3grp {
+		fsl,pins = <
+			MX8MP_IOMUXC_ECSPI1_SCLK__UART3_DCE_RX	0x140
+			MX8MP_IOMUXC_ECSPI1_MOSI__UART3_DCE_TX	0x140
+		>;
+	};
+};

--- a/arch/arm64/boot/dts/freescale/beluga.dts
+++ b/arch/arm64/boot/dts/freescale/beluga.dts
@@ -387,12 +387,6 @@
 	status = "okay";
 };
 
-&uart3 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pinctrl_uart3>;
-	status = "okay";
-};
-
 /* USB1 - Type C PORT 1 */
 &usb3_phy0 {
        status = "okay";
@@ -583,13 +577,6 @@
 		fsl,pins = <
 			MX8MP_IOMUXC_UART2_RXD__UART2_DCE_RX	0x49
 			MX8MP_IOMUXC_UART2_TXD__UART2_DCE_TX	0x49
-		>;
-	};
-
-	pinctrl_uart3: uart3grp {
-		fsl,pins = <
-			MX8MP_IOMUXC_ECSPI1_SCLK__UART3_DCE_RX	0x140
-			MX8MP_IOMUXC_ECSPI1_MOSI__UART3_DCE_TX	0x140
 		>;
 	};
 


### PR DESCRIPTION
UART3 is also used from co-processor Cortex-M7. To avoid concurrent access we provide the enabling of it as an overlay, which can be applied if co-processor will not be used.

Fixes: dd6ef5c3dfd4 ("arm64: dts: beluga: add support for UART3")